### PR TITLE
Fix for Microsoft/Detours GIT repository default branch name change.

### DIFF
--- a/detours/CMakeLists.txt
+++ b/detours/CMakeLists.txt
@@ -4,6 +4,7 @@ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 ExternalProject_Add(
 	Detours_project
 	GIT_REPOSITORY "https://github.com/Microsoft/Detours.git"
+	GIT_TAG "main"
 	CONFIGURE_COMMAND ""
 	BINARY_DIR	"${CMAKE_CURRENT_BINARY_DIR}/Detours_project-prefix/src/Detours_project/src"
 	BUILD_COMMAND ${CMAKE_COMMAND} -E env DETOURS_TARGET_PROCESSOR=X64 nmake


### PR DESCRIPTION
Hi @citronneur absolutely great repository.  CMAKE work of art :)

Microsoft have changed their branch naming conventions I believe so when running on latest VS2022 CMAKE `ExternalProject` module defaulted to pull `master` branch which did not exist.